### PR TITLE
ISSUE #26 Add PEA, PEI, PER

### DIFF
--- a/venv/pysnes/cpu.py
+++ b/venv/pysnes/cpu.py
@@ -1042,6 +1042,26 @@ class CPU65816(object):
             self.A = result
             self.cycles += 6 - self.m()
             self.PC = self.PC + 1
+        # PEA imm
+        elif opcode == 0xFA:
+            bytes = self.fetch_twobyte(code)
+            self.push_stack(bytes)
+            self.cycles += 5
+            self.PC = self.PC + 1
+        # PEI dir
+        elif opcode == 0xD4:
+            byte = self.fetch_byte(code)
+            address = compute_addr.dp(byte, self.DP)
+            value = self.read_memory(address, byte_num = 2, wrapp=True)
+            self.push_stack(value)
+            self.cycles = 6 + self.w()
+            self.PC = self.PC + 1
+        # PER imm
+        elif opcode == 0x62:
+            bytes = self.fetch_twobyte(code)
+            self.push_stack(bytes + self.PC+1)
+            self.cycles += 6
+            self.PC = self.PC + 1
         # PHA
         elif opcode == 0x48:
             self.push_stack(self.A)

--- a/venv/pysnes/test/test_cpu_push_pull.py
+++ b/venv/pysnes/test/test_cpu_push_pull.py
@@ -51,7 +51,7 @@ def test_PEI2():
     mem.write(0x001235, 0x56)
     cpu.P = 0b00000000  # M and X Flag have no effect on PEI
 
-    cpu.fetch_decode_execute([0xD4, 0x33]) # PEI ($34)
+    cpu.fetch_decode_execute([0xD4, 0x33]) # PEI ($33)
 
     assert mem.read(0x0001FF) == 0x56 # high
     assert mem.read(0x0001FE) == 0x78 # low
@@ -70,7 +70,23 @@ def test_PER():
     cpu.fetch_decode_execute(nops+[0x62, 0x34, 0x12]) # PER #$1234
 
     assert mem.read(0x0001FF) == 0x12 # high
-    assert mem.read(0x0001FE) == 0x57 # low (1234+PC+3 = 1254)
+    assert mem.read(0x0001FE) == 0x57 # low (1234+PC+3 = 1257)
+    assert cpu.SP == 0x01FD
+    assert cpu.cycles == 6
+
+
+def test_PER2():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.SP = 0x01FF
+    cpu.PC = 0x12
+    cpu.P = 0b00000000  # M and X Flag have no effect on PER
+
+    nops = [0xEA] * cpu.PC
+    cpu.fetch_decode_execute(nops + [0x62, 0x12, 0x00])  # PER #$0012
+
+    assert mem.read(0x0001FF) == 0x00  # high
+    assert mem.read(0x0001FE) == 0x27  # low (0012+PC+3 = 0027)
     assert cpu.SP == 0x01FD
     assert cpu.cycles == 6
 

--- a/venv/pysnes/test/test_cpu_push_pull.py
+++ b/venv/pysnes/test/test_cpu_push_pull.py
@@ -11,6 +11,70 @@ class MemoryMock(object):
         self.ram[address] = value
 
 
+def test_PEA():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.SP = 0x01FF
+    cpu.P = 0b00000000  # M and X Flag have no effect on PEA
+
+    cpu.fetch_decode_execute([0xFA, 0x34, 0x12]) # PEA #$1234
+
+    assert mem.read(0x0001FF) == 0x12 # high
+    assert mem.read(0x0001FE) == 0x34 # low
+    assert cpu.SP == 0x01FD
+    assert cpu.cycles == 5
+
+
+def test_PEI():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.SP = 0x01FF
+    cpu.DP = 0x1200
+    mem.write(0x001234, 0x78) # low: D + 0x34
+    mem.write(0x001235, 0x56)
+    cpu.P = 0b00000000  # M and X Flag have no effect on PEI
+
+    cpu.fetch_decode_execute([0xD4, 0x34]) # PEI ($34)
+
+    assert mem.read(0x0001FF) == 0x56 # high
+    assert mem.read(0x0001FE) == 0x78 # low
+    assert cpu.SP == 0x01FD
+    assert cpu.cycles == 6 # DL=0 => w=0
+
+
+def test_PEI2():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.SP = 0x01FF
+    cpu.DP = 0x1201 # DH=12 DL=01
+    mem.write(0x001234, 0x78) # low: D + 0x33
+    mem.write(0x001235, 0x56)
+    cpu.P = 0b00000000  # M and X Flag have no effect on PEI
+
+    cpu.fetch_decode_execute([0xD4, 0x33]) # PEI ($34)
+
+    assert mem.read(0x0001FF) == 0x56 # high
+    assert mem.read(0x0001FE) == 0x78 # low
+    assert cpu.SP == 0x01FD
+    assert cpu.cycles == 7 # DL!=0 => w=1
+
+
+def test_PER():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.SP = 0x01FF
+    cpu.PC = 0x20
+    cpu.P = 0b00000000  # M and X Flag have no effect on PER
+
+    nops = [0xEA] * cpu.PC
+    cpu.fetch_decode_execute(nops+[0x62, 0x34, 0x12]) # PER #$1234
+
+    assert mem.read(0x0001FF) == 0x12 # high
+    assert mem.read(0x0001FE) == 0x57 # low (1234+PC+3 = 1254)
+    assert cpu.SP == 0x01FD
+    assert cpu.cycles == 6
+
+
 def test_PHK():
     mem = MemoryMock()
     cpu = CPU65816(mem)


### PR DESCRIPTION
Iam not sure about the +1 in self.PC+1 in cpu.py (PER)

The manual https://wiki.nesdev.com/w/images/7/76/Programmanual.pdf at page 172
"Using the instruction [...] in your source program causes the assembler to calculate the offset from [...] (from the instruction following the PER instruction "

So self.PC+addr is calculate from the instruction after `PER addr`