### PR TITLE
ISSUE #13 Add ADC opcodes (only two's complement) 

### DIFF
--- a/venv/pysnes/cpu.py
+++ b/venv/pysnes/cpu.py
@@ -32,7 +32,7 @@ class CPU65816(object):
             bytes = self.read_memory(address_pointer, byte_num=2, wrapp=True)  # zero bank wrapping!
             address = compute_addr.abs(bytes, self.DBR)
             value = self.read_memory(address, byte_num=2 - self.m())
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 7 - self.m() + self.w()
@@ -42,7 +42,7 @@ class CPU65816(object):
             byte = self.fetch_byte(code)
             address = compute_addr.stack(byte, self.SP)
             value = self.read_memory(address, byte_num = 2 - self.m(), wrapp=True) # zero bank wrapping
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 5 - self.m()
@@ -52,7 +52,7 @@ class CPU65816(object):
             byte = self.fetch_byte(code)
             address = compute_addr.dp(byte, self.DP)
             value = self.read_memory(address, byte_num = 2 - self.m(), wrapp=True) # zero bank wrapping!
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 4 - self.m() + self.w()
@@ -63,7 +63,7 @@ class CPU65816(object):
             address_pointer = compute_addr.dp(byte, self.DP)
             address = self.read_memory(address_pointer, byte_num=3, wrapp=True) # zero bank wrapping!
             value = self.read_memory(address, byte_num = 2 - self.m())
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 7 - self.m() + self.w()
@@ -74,7 +74,7 @@ class CPU65816(object):
                 const = self.fetch_byte(code)
             else:
                 const = self.fetch_twobyte(code)
-            result = self.add_twos_complement(self.A, const + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, const + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 3 - self.m()
@@ -84,7 +84,7 @@ class CPU65816(object):
             bytes = self.fetch_twobyte(code)
             address = compute_addr.abs(bytes, self.DBR)
             value = self.read_memory(address, byte_num = 2 - self.m())
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 5 - self.m()
@@ -93,7 +93,7 @@ class CPU65816(object):
         elif opcode == 0x6F:
             address = self.fetch_threebyte(code)
             value = self.read_memory(address, byte_num=2 - self.m())  # no wrapping
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 6 - self.m()
@@ -105,7 +105,7 @@ class CPU65816(object):
             bytes = self.read_memory(address_pointer, byte_num=2, wrapp=True) # zero bank wrapping!
             address = compute_addr.abs_y(bytes, self.DBR, self.Y, self.isX())
             value = self.read_memory(address, byte_num = 2 - self.m())
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 7 - self.m() + self.w() - self.x() + self.x() * self.p()
@@ -117,7 +117,7 @@ class CPU65816(object):
             bytes = self.read_memory(address_pointer, byte_num=2, wrapp=True) # zero bank wrapping!
             address = compute_addr.abs(bytes, self.DBR)
             value = self.read_memory(address, byte_num=2-self.m())
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 6 - self.m() + self.w()
@@ -129,7 +129,7 @@ class CPU65816(object):
             bytes = self.read_memory(address_pointer, byte_num=2, wrapp=True)  # zero bank wrapping!
             address = compute_addr.abs_y(bytes, self.DBR, self.Y, self.isX())
             value = self.read_memory(address, byte_num=2 - self.m())
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 8 - self.m()
@@ -139,7 +139,7 @@ class CPU65816(object):
             byte = self.fetch_byte(code)
             address = compute_addr.dp_x(byte, self.DP, self.X, self.isX())
             value = self.read_memory(address, byte_num = 2 - self.m(), wrapp=True) # zero bank wrapping!
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 5 - self.m() + self.w()
@@ -151,7 +151,7 @@ class CPU65816(object):
             bytes = self.read_memory(address_pointer, byte_num=3, wrapp=True) # zero bank wrapping!
             address = compute_addr.long_y(bytes, self.Y, self.isX())
             value = self.read_memory(address, byte_num = 2 - self.m())
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 7 - self.m() + self.w()
@@ -161,7 +161,7 @@ class CPU65816(object):
             bytes = self.fetch_twobyte(code)
             address = compute_addr.abs_y(bytes, self.DBR, self.Y, self.isX())
             value = self.read_memory(address, byte_num = 2 - self.m())
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 6 - self.m() - self.x() + self.x() * self.p()
@@ -171,7 +171,7 @@ class CPU65816(object):
             bytes = self.fetch_twobyte(code)
             address = compute_addr.abs_x(bytes, self.DBR, self.X, self.isX())
             value = self.read_memory(address, byte_num = 2 - self.m())
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 6 - self.m() - self.x() + self.x() * self.p()
@@ -181,7 +181,7 @@ class CPU65816(object):
             bytes = self.fetch_threebyte(code)
             address = compute_addr.long_x(bytes, self.X, self.isX())
             value = self.read_memory(address, byte_num = 2 - self.m())
-            result = self.add_twos_complement(self.A, value + self.c(), self.isM(), affectCVFlags=True)
+            result = self.add_twos_complement(self.A, value + self.c(), self.isM())
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 6 - self.m()
@@ -969,7 +969,10 @@ class CPU65816(object):
             self.PC = self.PC + 1
         # INC A
         elif opcode == 0x1A:
-            result = self.add_twos_complement(self.A, 1, is8BitMode = self.isM())
+            if self.isM():
+                result = (self.A + 1) & 0x0000FF
+            else:
+                result = (self.A + 1) & 0x00FFFF
             self.compute_NZflags(result, self.isM())
             self.A = result
             self.cycles += 2
@@ -979,7 +982,10 @@ class CPU65816(object):
             byte = self.fetch_byte(code)
             address = compute_addr.dp(byte, self.DP)
             value = self.read_memory(address, byte_num = 2 - self.m(), wrapp=True) # zero bank wrapping!
-            result = self.add_twos_complement(value, 1, is8BitMode = self.isM())
+            if self.isM():
+                result = (value + 1) & 0x0000FF
+            else:
+                result = (value + 1) & 0x00FFFF
             self.compute_NZflags(result, self.isM())
             self.write_memory(address, result, byte_num = 2 - self.m(), wrapp=True)  # zero bank wrapping!
             self.cycles += 7 - self.m()*2 + self.w()
@@ -989,7 +995,10 @@ class CPU65816(object):
             bytes = self.fetch_twobyte(code)
             address = compute_addr.abs(bytes, self.DBR)
             value = self.read_memory(address, byte_num = 2 - self.m())
-            result = self.add_twos_complement(value, 1, is8BitMode = self.isM())
+            if self.isM():
+                result = (value + 1) & 0x0000FF
+            else:
+                result = (value + 1) & 0x00FFFF
             self.compute_NZflags(result, self.isM())
             self.write_memory(address, result, byte_num = 2 - self.m()) # no wrapping
             self.cycles += 8 - self.m() * 2
@@ -999,7 +1008,10 @@ class CPU65816(object):
             byte = self.fetch_byte(code)
             address = compute_addr.dp_x(byte, self.DP, self.X, self.isX())
             value = self.read_memory(address, byte_num = 2 - self.m(), wrapp=True) # zero bank wrapping!
-            result = self.add_twos_complement(value, 1, is8BitMode = self.isM())
+            if self.isM():
+                result = (value + 1) & 0x0000FF
+            else:
+                result = (value + 1) & 0x00FFFF
             self.compute_NZflags(result, self.isM())
             self.write_memory(address, result, byte_num = 2 - self.m(), wrapp=True)  # zero bank wrapping!
             self.cycles += 8 - self.m() * 2 + self.w()
@@ -1009,21 +1021,30 @@ class CPU65816(object):
             bytes = self.fetch_twobyte(code)
             address = compute_addr.abs_x(bytes, self.DBR, self.X, self.isX())
             value = self.read_memory(address, byte_num = 2 - self.m())
-            result = self.add_twos_complement(value, 1, is8BitMode=self.isM())
+            if self.isM():
+                result = (value + 1) & 0x0000FF
+            else:
+                result = (value + 1) & 0x00FFFF
             self.compute_NZflags(result, self.isM())
             self.write_memory(address, result, byte_num = 2 - self.m())
             self.cycles += 9 - self.m() * 2
             self.PC = self.PC + 1
         # INX
         elif opcode == 0xE8:
-            result = self.add_twos_complement(self.X, 1, is8BitMode = self.isX())
+            if self.isX():
+                result = (self.X + 1) & 0x0000FF
+            else:
+                result = (self.X + 1) & 0x00FFFF
             self.compute_NZflags(result, self.isX())
             self.X = result
             self.cycles += 2
             self.PC = self.PC + 1
         # INY
         elif opcode == 0xC8:
-            result = self.add_twos_complement(self.Y, 1, is8BitMode = self.isX())
+            if self.isX():
+                result = (self.Y + 1) & 0x0000FF
+            else:
+                result = (self.Y + 1) & 0x00FFFF
             self.compute_NZflags(result, self.isX())
             self.Y = result
             self.cycles += 2
@@ -2138,28 +2159,26 @@ class CPU65816(object):
 
 
     # compute twos complement by hand.
-    def add_twos_complement(self, value, arg, is8BitMode, affectCVFlags=False):
+    def add_twos_complement(self, value, arg, is8BitMode):
         if is8BitMode:
-            if affectCVFlags:
-                if value <= 0x7F and value + arg > 0x7F:  # MAX_INT (SIGNED)
-                    self.setV()  # Overflow Flag
-                else:
-                    self.clearV()
-                if value <= 0xFF and value + arg > 0xFF:  # MAX_INT (UNSIGNED)
-                    self.setC()  # Carry Flag
-                else:
-                    self.clearC()
+            if value <= 0x7F and value + arg > 0x7F:  # MAX_INT (SIGNED)
+                self.setV()  # Overflow Flag
+            else:
+                self.clearV()
+            if value <= 0xFF and value + arg > 0xFF:  # MAX_INT (UNSIGNED)
+                self.setC()  # Carry Flag
+            else:
+                self.clearC()
             result = (value + arg) & 0x0000FF
         else:
-            if affectCVFlags:
-                if value <= 0x7FFF and value + arg > 0x7FFF:  # MAX_INT (SIGNED)
-                    self.setV()  # Overflow Flag
-                else:
-                    self.clearV()
-                if value <= 0xFFFF and value + arg > 0xFFFF:  # MAX_INT (UNSIGNED)
-                    self.setC()  # Carry Flag
-                else:
-                    self.clearC()
+            if value <= 0x7FFF and value + arg > 0x7FFF:  # MAX_INT (SIGNED)
+                self.setV()  # Overflow Flag
+            else:
+                self.clearV()
+            if value <= 0xFFFF and value + arg > 0xFFFF:  # MAX_INT (UNSIGNED)
+                self.setC()  # Carry Flag
+            else:
+                self.clearC()
             result = (value + arg) & 0x00FFFF
         return result
 

--- a/venv/pysnes/test/test_cpu_adc.py
+++ b/venv/pysnes/test/test_cpu_adc.py
@@ -1,0 +1,518 @@
+from pysnes.cpu import CPU65816
+
+# .../PySNES/venv/$ py.test pysnes/test/
+
+
+class MemoryMock(object):
+    def __init__(self):
+        self.ram = {}
+
+    def read(self, address):
+        return self.ram[address]
+
+    def write(self, address, value):
+        self.ram[address] = value
+
+
+def test_ADC_imm_setZ_8bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00100000  # 8 Bit mode
+    cpu.e = 0
+    cpu.A = 0x00
+
+    cpu.fetch_decode_execute([0x69, 0x00])
+
+    assert cpu.cycles == 2
+    assert cpu.A == 0x00
+    assert cpu.P == 0b00100010  # zero flag
+
+
+def test_ADC_imm_clearZ_8bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00100010  # 8 Bit mode
+    cpu.e = 0
+    cpu.A = 0x00
+
+    cpu.fetch_decode_execute([0x69, 0x10])
+
+    assert cpu.cycles == 2
+    assert cpu.A == 0x10
+    assert cpu.P == 0b00100000  # no zero flag
+
+
+def test_ADC_imm_setN_8bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00100000  # 8 Bit mode
+    cpu.e = 0
+    cpu.A = 0x8F
+
+    cpu.fetch_decode_execute([0x69, 0x00])
+
+    assert cpu.cycles == 2
+    assert cpu.A == 0x8F
+    assert cpu.P == 0b10100000  # negative flag
+
+
+def test_ADC_imm_clearN_8bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b10100000  # 8 Bit mode
+    cpu.e = 0
+    cpu.A = 0x00
+
+    cpu.fetch_decode_execute([0x69, 0x10])
+
+    assert cpu.cycles == 2
+    assert cpu.A == 0x10
+    assert cpu.P == 0b00100000  # no negative flag
+
+
+def test_ADC_imm_setV_8bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00100000  # 8 Bit mode
+    cpu.e = 0
+    cpu.A = 0x7F
+
+    cpu.fetch_decode_execute([0x69, 0x01])
+
+    assert cpu.cycles == 2
+    assert cpu.A == 0x80
+    assert cpu.P == 0b11100000  # overflow + negative flag
+
+
+def test_ADC_imm_clearV_8bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b11100000  # 8 Bit mode
+    cpu.e = 0
+    cpu.A = 0x00
+
+    cpu.fetch_decode_execute([0x69, 0x10])
+
+    assert cpu.cycles == 2
+    assert cpu.A == 0x10
+    assert cpu.P == 0b00100000  # no overflow + negative flag
+
+
+def test_ADC_imm_setC_8bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00100000  # 8 Bit mode
+    cpu.e = 0
+    cpu.A = 0xFF
+
+    cpu.fetch_decode_execute([0x69, 0x02])
+
+    assert cpu.cycles == 2
+    assert cpu.A == 0x01
+    assert cpu.P == 0b00100001  # carry flag
+
+
+def test_ADC_imm_clearC_8bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00100001  # 8 Bit mode
+    cpu.e = 0
+    cpu.A = 0x01
+
+    cpu.fetch_decode_execute([0x69, 0x01])
+
+    assert cpu.cycles == 2
+    assert cpu.A == 0x03  # A + const + carry = 3
+    assert cpu.P == 0b00100000  # no carry flag
+
+
+def test_ADC_imm_setZ_16bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00000000  # 16 Bit mode
+    cpu.e = 0
+    cpu.A = 0x0000
+
+    cpu.fetch_decode_execute([0x69, 0x00, 0x00])
+
+    assert cpu.cycles == 3
+    assert cpu.A == 0x0000
+    assert cpu.P == 0b00000010  # zero flag
+
+
+def test_ADC_imm_clearZ_16bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00000010  # 16 Bit mode
+    cpu.e = 0
+    cpu.A = 0x0000
+
+    cpu.fetch_decode_execute([0x69, 0x10, 0x00])
+
+    assert cpu.cycles == 3
+    assert cpu.A == 0x0010
+    assert cpu.P == 0b00000000  # no zero flag
+
+
+def test_ADC_imm_setN_16bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00000000  # 16 Bit mode
+    cpu.e = 0
+    cpu.A = 0x8FFF
+
+    cpu.fetch_decode_execute([0x69, 0x00, 0x00])
+
+    assert cpu.cycles == 3
+    assert cpu.A == 0x8FFF
+    assert cpu.P == 0b10000000  # negative flag
+
+
+def test_ADC_imm_clearN_16bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b10000000  # 16 Bit mode
+    cpu.e = 0
+    cpu.A = 0x0000
+
+    cpu.fetch_decode_execute([0x69, 0x10, 0x00])
+
+    assert cpu.cycles == 3
+    assert cpu.A == 0x0010
+    assert cpu.P == 0b00000000  # no negative flag
+
+
+def test_ADC_imm_setV_16bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00000000  # 16 Bit mode
+    cpu.e = 0
+    cpu.A = 0x7FFF
+
+    cpu.fetch_decode_execute([0x69, 0x01, 0x00])
+
+    assert cpu.cycles == 3
+    assert cpu.A == 0x8000
+    assert cpu.P == 0b11000000  # overflow + negative flag
+
+
+def test_ADC_imm_clearV_16bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b11000000  # 16 Bit mode
+    cpu.e = 0
+    cpu.A = 0x0000
+
+    cpu.fetch_decode_execute([0x69, 0x10, 0x00])
+
+    assert cpu.cycles == 3
+    assert cpu.A == 0x0010
+    assert cpu.P == 0b00000000  # no overflow + negative flag
+
+
+def test_ADC_imm_setC_16bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00000000  # 16 Bit mode
+    cpu.e = 0
+    cpu.A = 0xFFFF
+
+    cpu.fetch_decode_execute([0x69, 0x02, 0x00])
+
+    assert cpu.cycles == 3
+    assert cpu.A == 0x0001
+    assert cpu.P == 0b00000001  # carry flag
+
+
+def test_ADC_imm_clearC_16bit():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00000001  # 16 Bit mode
+    cpu.e = 0
+    cpu.A = 0x0001
+
+    cpu.fetch_decode_execute([0x69, 0x01, 0x00])
+
+    assert cpu.cycles == 3
+    assert cpu.A == 0x03  # A + const + carry = 3
+    assert cpu.P == 0b00000000  # no carry flag
+
+
+def test_ADC_DP_indexed_indirect_X():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b11000010  # 16 Bit mode
+    cpu.e = 0
+    cpu.DBR = 0x80
+    cpu.DP = 0x0020
+    cpu.X = 0x0004
+    cpu.A = 0x1111
+
+    mem.write(0x000026, 0x09)
+    mem.write(0x000027, 0x88)
+
+    mem.write(0x808809, 0x22)
+    mem.write(0x80880A, 0x22)
+
+    cpu.fetch_decode_execute([0x61, 0x02])
+
+    assert cpu.cycles == 8
+    assert cpu.A == 0x3333
+    assert cpu.P == 0b00000000  # no flags
+
+
+def test_ADC_stack_relative():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b11000010  # 16 Bit mode
+    cpu.e = 0
+    cpu.SP = 0x1FF0
+    cpu.A = 0x7777
+
+    mem.write(0x001FF1, 0x11)
+    mem.write(0x001FF2, 0x11)
+
+    cpu.fetch_decode_execute([0x63, 0x01])
+
+    assert cpu.cycles == 5
+    assert cpu.A == 0x8888
+    assert cpu.P == 0b11000000  # negative and overflow flag
+
+
+def test_ADC_DP():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00000000  # 16 Bit mode
+    cpu.e = 0
+    cpu.DP = 0x1200
+    cpu.A = 0xAAAA
+
+    mem.write(0x001234, 0xAA)
+    mem.write(0x001235, 0xAA)
+
+    cpu.fetch_decode_execute([0x65, 0x34])
+
+    assert cpu.cycles == 4
+    assert cpu.A == 0x5554
+    assert cpu.P == 0b00000001  # carry flag
+
+
+def test_ADC_DP_indirect_long():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b11000000  # 16 Bit mode
+    cpu.e = 0
+    cpu.DP = 0x0020
+    cpu.A = 0xFFFF
+
+    mem.write(0x000030, 0x30)
+    mem.write(0x000031, 0x40)
+    mem.write(0x000032, 0x23)
+
+    mem.write(0x234030, 0x01)
+    mem.write(0x234031, 0x00)
+
+    cpu.fetch_decode_execute([0x67, 0x10])
+
+    assert cpu.cycles == 8
+    assert cpu.A == 0x0000
+    assert cpu.P == 0b00000011  # carry and zero flag
+
+
+def test_ADC_absolute():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b11000011  # 16 Bit mode
+    cpu.e = 0
+    cpu.DBR = 0x12
+    cpu.A = 0x7000
+
+    mem.write(0x123456, 0x00)
+    mem.write(0x123457, 0x10)
+
+    cpu.fetch_decode_execute([0x6D, 0x56, 0x34])
+
+    assert cpu.cycles == 5
+    assert cpu.A == 0x8001
+    assert cpu.P == 0b11000000  # negative and overflow flag
+
+
+def test_ADC_long():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b11000010 # 16 Bit mode
+    cpu.e = 0
+    cpu.A = 0x0000
+
+    mem.write(0x123456, 0xFF)
+    mem.write(0x123457, 0x0F)
+
+    cpu.fetch_decode_execute([0x6F, 0x56, 0x34, 0x12])
+
+    assert cpu.cycles == 6
+    assert cpu.A == 0x0FFF
+    assert cpu.P == 0b00000000  # no flags
+
+
+def test_ADC_DP_indirect_indexed_Y():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00000000  # 16 Bit mode
+    cpu.e = 0
+    cpu.DBR = 0x80
+    cpu.DP = 0x0020
+    cpu.Y = 0x0001
+    cpu.A = 0x0FFF
+
+    mem.write(0x000030, 0x30)
+    mem.write(0x000031, 0x40)
+
+    mem.write(0x804031, 0x00)
+    mem.write(0x804032, 0x0F)
+
+    cpu.fetch_decode_execute([0x71, 0x10])
+
+    assert cpu.cycles >= 7
+    assert cpu.A == 0x1EFF
+    assert cpu.P == 0b00000000  # no flags
+
+
+def test_ADC_DP_indirect():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00000000 # 16 Bit mode
+    cpu.e = 0
+    cpu.DBR = 0x80
+    cpu.DP = 0x0020
+    cpu.A = 0x1234
+
+    mem.write(0x000030, 0x30)
+    mem.write(0x000031, 0x40)
+
+    mem.write(0x804030, 0x21)
+    mem.write(0x804031, 0x43)
+
+    cpu.fetch_decode_execute([0x72, 0x10])
+
+    assert cpu.cycles == 7
+    assert cpu.A == 0x5555
+    assert cpu.P == 0b00000000
+
+
+def test_ADC_stack_relative_indirect_indexed_Y():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00000001  # 16 Bit mode
+    cpu.e = 0
+    cpu.SP = 0xFF10
+    cpu.Y = 0x50
+    cpu.DBR = 0x12
+    cpu.A = 0x7FFF
+
+    mem.write(0x00000A, 0xF0) # 0x1000A becomes 0x000A
+    mem.write(0x00000B, 0xFF) # 0x1000B becomes 0x000B
+
+    mem.write(0x130040, 0x00)
+    mem.write(0x130041, 0x80)
+
+    cpu.fetch_decode_execute([0x73, 0xFA])
+    assert cpu.cycles == 8
+    assert cpu.A == 0x0000
+    assert cpu.P == 0b01000011  # negative, zero and carry flag
+
+
+def test_ADC_DP_indexed_X():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b11000010  # 16 Bit mode
+    cpu.e = 0
+    cpu.DP = 0x0020
+    cpu.X = 0x0004
+    cpu.A = 0x0F0F
+
+    mem.write(0x000054, 0xF0)
+    mem.write(0x000055, 0x00)
+
+    cpu.fetch_decode_execute([0x75, 0x30])
+
+    assert cpu.cycles == 6
+    assert cpu.A == 0x0FFF
+    assert cpu.P == 0b00000000  # no flags
+
+
+def test_ADC_DP_indirect_long_indexed_Y():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00000001  # 16 Bit mode
+    cpu.e = 0
+    cpu.DP = 0x0020
+    cpu.Y = 0x0001
+    cpu.A = 0xFFFF
+
+    mem.write(0x000030, 0x30)
+    mem.write(0x000031, 0x40)
+    mem.write(0x000032, 0x50)
+
+    mem.write(0x504031, 0x00)
+    mem.write(0x504032, 0x00)
+
+    cpu.fetch_decode_execute([0x77, 0x10])
+
+    assert cpu.cycles == 8
+    assert cpu.A == 0x0000
+    assert cpu.P == 0b00000011  # zero and carry flag
+
+
+def test_ADC_abs_indexed_Y():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b00000000  # 16 Bit mode
+    cpu.e = 0
+    cpu.DBR = 0x80
+    cpu.Y = 0x0001
+    cpu.A = 0x7FFF
+
+    mem.write(0x808001, 0x01) # no wrapping
+    mem.write(0x808002, 0x00)
+
+    cpu.fetch_decode_execute([0x79, 0x00, 0x80])
+
+    assert cpu.cycles >= 6
+    assert cpu.A == 0x8000
+    assert cpu.P == 0b11000000  # overflow and negative flag
+
+
+def test_ADC_abs_indexed_X():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b11000011  # 16 Bit mode
+    cpu.e = 0
+    cpu.DBR = 0x80
+    cpu.X = 0x0001
+    cpu.A = 0xFFFF
+
+    mem.write(0x808001, 0xFF) # no wrapping
+    mem.write(0x808002, 0xFF)
+
+    cpu.fetch_decode_execute([0x7D, 0x00, 0x80])
+
+    assert cpu.cycles >= 6
+    assert cpu.A == 0xFFFF
+    assert cpu.P == 0b10000001  # carry and negative flag
+
+
+def test_ADC_long_indexed_X():
+    mem = MemoryMock()
+    cpu = CPU65816(mem)
+    cpu.P = 0b11000011  # 16 Bit mode
+    cpu.e = 0
+    cpu.X = 0x0001
+    cpu.A = 0x1234
+
+    mem.write(0x808001, 0xCD)
+    mem.write(0x808002, 0xAB)
+
+    cpu.fetch_decode_execute([0x7F, 0x00, 0x80, 0x80])
+    assert cpu.cycles == 6
+    assert cpu.A == 0xBE02
+    assert cpu.P == 0b11000000  # negative and overflow flag

--- a/venv/pysnes/test/test_cpu_arithmetic_INC.py
+++ b/venv/pysnes/test/test_cpu_arithmetic_INC.py
@@ -68,7 +68,7 @@ def test_INC_Zero_8BIT():
     assert cpu.P == 0b00100010  # zero flag
 
 
-def test_INC_overflow():
+def test_INC_no_overflow():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00000000  # 16 Bit mode
@@ -79,10 +79,10 @@ def test_INC_overflow():
 
     assert cpu.cycles == 2
     assert cpu.A == 0x8000      # -32.768 (MIN INT)
-    assert cpu.P == 0b11000000  # negative flag, overflow flag
+    assert cpu.P == 0b10000000  # negative flag, no overflow flag
 
 
-def test_INC_overflow_8BIT():
+def test_INC_no_overflow_8BIT():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00100000  # 8 Bit mode
@@ -93,7 +93,7 @@ def test_INC_overflow_8BIT():
 
     assert cpu.cycles == 2
     assert cpu.A == 0x80        # -128 (MIN INT)
-    assert cpu.P == 0b11100000  # negative flag, overflow flag
+    assert cpu.P == 0b10100000  # negative flag, no overflow flag
 
 
 def test_INC_DP():
@@ -164,7 +164,7 @@ def test_INC_DP_Zero_8BIT():
     assert cpu.P == 0b00100010 # zero flag
 
 
-def test_INC_DP_overflow():
+def test_INC_DP_no_overflow():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00000000  # 16 Bit mode
@@ -178,10 +178,10 @@ def test_INC_DP_overflow():
     assert cpu.cycles in (5, 6, 7, 8)
     assert mem.read(0x001234) == 0x00 # -32.768 (MIN INT)
     assert mem.read(0x001235) == 0x80
-    assert cpu.P == 0b11000000 # negative flag, overflow flag
+    assert cpu.P == 0b10000000 # negative flag, no overflow flag
 
 
-def test_INC_DP_overflow_8BIT():
+def test_INC_DP_no_overflow_8BIT():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00100000  # 8 Bit mode
@@ -195,7 +195,7 @@ def test_INC_DP_overflow_8BIT():
     assert cpu.cycles in (5, 6, 7, 8)
     assert mem.read(0x001234) == 0x80 # -128 (MIN INT)
     assert mem.read(0x001235) == 0x00
-    assert cpu.P == 0b11100000 # negative flag, overflow flag
+    assert cpu.P == 0b10100000 # negative flag, no overflow flag
 
 
 def test_INC_absolute():
@@ -266,7 +266,7 @@ def test_INC_absolute_Zero_8BIT():
     assert cpu.P == 0b00100010 # zero flag
 
 
-def test_INC_absolute_overflow():
+def test_INC_absolute_no_overflow():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00000000  # 16 Bit mode
@@ -280,10 +280,10 @@ def test_INC_absolute_overflow():
     assert cpu.cycles == 8
     assert mem.read(0x123456) == 0x00 # -32.768 (MIN INT)
     assert mem.read(0x123457) == 0x80
-    assert cpu.P == 0b11000000 # negative flag, overflow flag
+    assert cpu.P == 0b10000000 # negative flag, no overflow flag
 
 
-def test_INC_absolute_overflow_8BIT():
+def test_INC_absolute_no_overflow_8BIT():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00100000  # 8 Bit mode
@@ -297,7 +297,7 @@ def test_INC_absolute_overflow_8BIT():
     assert cpu.cycles == 6
     assert mem.read(0x123456) == 0x80 # -128 (MIN INT)
     assert mem.read(0x123457) == 0x00
-    assert cpu.P == 0b11100000 # negative flag, overflow flag
+    assert cpu.P == 0b10100000 # negative flag, no overflow flag
 
 
 def test_INC_DP_indexed_X():
@@ -376,7 +376,7 @@ def test_INC_DP_indexed_X_Zero_8BIT():
     assert cpu.P == 0b00100010  # zero flag
 
 
-def test_INC_DP_indexed_X_overflow():
+def test_INC_DP_indexed_X_no_overflow():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00000000  # 16 Bit mode
@@ -392,10 +392,10 @@ def test_INC_DP_indexed_X_overflow():
     assert cpu.cycles in (8, 9)
     assert mem.read(0x000054) == 0x00 # -32.768 (MIN INT)
     assert mem.read(0x000055) == 0x80
-    assert cpu.P == 0b11000000  # negative flag, overflow flag
+    assert cpu.P == 0b10000000  # negative flag, no overflow flag
 
 
-def test_INC_DP_indexed_X_overflow_8BIT():
+def test_INC_DP_indexed_X_no_overflow_8BIT():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00100000  # 8 Bit mode
@@ -411,7 +411,7 @@ def test_INC_DP_indexed_X_overflow_8BIT():
     assert cpu.cycles in (6, 7)
     assert mem.read(0x000054) == 0x80 # -128 (MIN INT)
     assert mem.read(0x000055) == 0x00
-    assert cpu.P == 0b11100000  # negative flag, overflow flag
+    assert cpu.P == 0b10100000  # negative flag, no overflow flag
 
 
 def test_INC_abs_indexed_X():
@@ -485,7 +485,7 @@ def test_INC_abs_indexed_X_Zero_8BIT():
     assert cpu.P == 0b00100010 # zero flag
 
 
-def test_INC_abs_indexed_X_overflow():
+def test_INC_abs_indexed_X_no_overflow():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00000000 # 16 Bit mode
@@ -500,10 +500,10 @@ def test_INC_abs_indexed_X_overflow():
     assert cpu.cycles == 9
     assert mem.read(0x808001) == 0x00 # -32.768 (MIN INT)
     assert mem.read(0x808002) == 0x80
-    assert cpu.P == 0b11000000 # negative flag, overflow flag
+    assert cpu.P == 0b10000000 # negative flag, no overflow flag
 
 
-def test_INC_abs_indexed_X_overflow_8BIT():
+def test_INC_abs_indexed_X_no_overflow_8BIT():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00100000 # 8 Bit mode
@@ -518,7 +518,7 @@ def test_INC_abs_indexed_X_overflow_8BIT():
     assert cpu.cycles == 7
     assert mem.read(0x808001) == 0x80 # -127(MIN INT)
     assert mem.read(0x808002) == 0x00
-    assert cpu.P == 0b11100000 # negative flag, overflow flag
+    assert cpu.P == 0b10100000 # negative flag, no overflow flag
 
 
 def test_INX():
@@ -577,7 +577,7 @@ def test_INX_Zero_8BIT():
     assert cpu.P == 0b00010010  # zero flag
 
 
-def test_INX_overflow():
+def test_INX_no_overflow():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00000000  # 16 Bit mode
@@ -588,10 +588,10 @@ def test_INX_overflow():
 
     assert cpu.cycles == 2
     assert cpu.X == 0x8000      # -32.768 (MIN INT)
-    assert cpu.P == 0b11000000  # negative flag, overflow flag
+    assert cpu.P == 0b10000000  # negative flag, no overflow flag
 
 
-def test_INX_overflow_8BIT():
+def test_INX_no_overflow_8BIT():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00010000  # 8 Bit mode
@@ -602,7 +602,7 @@ def test_INX_overflow_8BIT():
 
     assert cpu.cycles == 2
     assert cpu.X == 0x80        # -128 (MIN INT)
-    assert cpu.P == 0b11010000  # negative flag, overflow flag
+    assert cpu.P == 0b10010000  # negative flag, no overflow flag
 
 
 def test_INY():
@@ -661,7 +661,7 @@ def test_INY_Zero_8BIT():
     assert cpu.P == 0b00010010  # zero flag
 
 
-def test_INY_overflow():
+def test_INY_no_overflow():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00000000  # 16 Bit mode
@@ -672,10 +672,10 @@ def test_INY_overflow():
 
     assert cpu.cycles == 2
     assert cpu.Y == 0x8000 # -32.768 (MIN INT)
-    assert cpu.P == 0b11000000  # negative flag, overflow flag
+    assert cpu.P == 0b10000000  # negative flag, no overflow flag
 
 
-def test_INY_overflow_8BIT():
+def test_INY_no_overflow_8BIT():
     mem = MemoryMock()
     cpu = CPU65816(mem)
     cpu.P = 0b00010000  # 8 Bit mode
@@ -686,4 +686,4 @@ def test_INY_overflow_8BIT():
 
     assert cpu.cycles == 2
     assert cpu.Y == 0x80 # -128 (MIN INT)
-    assert cpu.P == 0b11010000  # negative flag, overflow flag
+    assert cpu.P == 0b10010000  # negative flag, no overflow flag


### PR DESCRIPTION
The changes to add_twos_complement (line 2141 in cpu.py onward) break the overflow tests for the inc opcodes. However, as seen in https://github.com/JonnyWalker/PySNES/pull/73, inc isn't supposed to set/clear the overflow flag anyway. I wasn't sure whether to remove those tests as part of this PR or to do so as a new issue so I left them in for now.